### PR TITLE
🎉 docs: Update README to specify University BenQ TVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 Welcome to **ADBenQ**! 🎉
 
-This is a desktop application built using PySide6 (Qt for Python) to control BenQ smart TVs via ADB (Android Debug Bridge).
+This is a desktop application built using PySide6 (Qt for Python) to control University BenQ smart TVs via ADB (Android Debug Bridge).
 
 > [!NOTE]
 > But hey, let's be real: the true goal of this project is to _learn Qt_ and become a future app developer!
@@ -44,12 +44,12 @@ Why **ADBenQ**?
 
 To run **ADBenQ**, you'll need:
 
-> [!WARNING]
-> Make sure ADB and Scrcpy is installed and accessible from your system's PATH!
-
 - Python 3.9 or later.
 - [ADB](https://developer.android.com/tools/adb) installed on your system.
 - [Scrcpy](https://github.com/Genymobile/scrcpy) installed on your system.
+
+> [!WARNING]
+> Make sure ADB and Scrcpy are accessible from your system's PATH!
 
 ## 🛠️ Installation
 


### PR DESCRIPTION
## Pull Request Description

### Title
🎉 docs: Update README to specify University BenQ TVs

### Description
This pull request updates the README file to clarify that ADBenQ is specifically designed to control University BenQ smart TVs. Additionally, the warning regarding the installation of ADB and Scrcpy has been simplified for improved readability. These enhancements aim to provide better user understanding and streamline the installation process.

### Changes Made
- Specified that ADBenQ is intended for University BenQ smart TVs.
- Simplified the installation warning for ADB and Scrcpy.

These modifications are intended to enhance the overall user experience and ensure that users have clear and concise instructions for using ADBenQ effectively.