### PR TITLE
✨ feat: support platform-specific builds in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,7 @@
-pyinstaller adbenq.spec
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  pyinstaller --distpath ./dist/linux adbenq.spec
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  pyinstaller --distpath ./dist/macos adbenq.spec
+elif [[ "$OSTYPE" == "win32" ]]; then
+  pyinstaller --distpath ./dist/windows adbenq.spec
+fi


### PR DESCRIPTION
Add conditional logic to build.sh for platform-specific 
PyInstaller commands. This change allows the script to 
determine the operating system and set the appropriate 
distribution path for Linux, macOS, and Windows, 
enhancing the build process for cross-platform compatibility.