### PR TITLE
✨ chore: update build workflow to trigger on main branch

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -2,8 +2,8 @@ name: Build macOS Executable
 
 on:
   push:
-    tags:
-      - "*"
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
### Pull Request Description

This pull request introduces an update to the GitHub Actions workflow by modifying the trigger conditions. 

**Key Changes:**
- The workflow is now set to trigger on pushes to the `main` branch rather than on tags. 

**Benefits:**
- This change ensures that builds are created for the latest changes in the `main` branch.
- It enhances the development workflow, allowing for more efficient testing of new features.

By implementing this update, we aim to streamline our CI/CD process and improve overall project responsiveness to changes.