### PR TITLE
✨ fix: update path for macOS build artifact verification

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Verify Build Artifacts
         run: |
-          if [ ! -f "dist/ADBenQ/ADBenQ" ]; then
+          if [ ! -f "dist/macos/ADBenQ/ADBenQ" ]; then
             echo "Build failed: Executable not found!"
             exit 1
           fi


### PR DESCRIPTION
### Pull Request Description

This pull request addresses an issue with the macOS build workflow by updating the file path used for artifact verification. 

**Changes Made:**
- Updated the path for the executable in the macOS build process to ensure that the verification step checks the correct directory.

**Benefits:**
- This fix prevents false negatives during the build process, enhancing the reliability of our continuous integration (CI) pipeline.

By implementing this change, we aim to improve the overall stability and accuracy of our build verification process on macOS.