### PR TITLE
✨ chore: update GitHub Actions to fetch latest release tag

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -42,14 +42,11 @@ jobs:
           mv dist/macos/ADBenQ/ADBenQ /tmp/ADBenQ
           tar -czf adbenq_macos_arm.tar.gz -C /tmp ADBenQ
 
-      - name: Get the latest release
-        id: latest_release
+      - name: Get Latest GitHub Release Tag
+        id: get_release_tag
         run: |
-          latest_release=$(curl -s https://api.github.com/repos/Zarox28/ADBenQ/releases/latest)
-          echo "Latest release: $latest_release"
-          release_tag=$(echo $latest_release | jq -r '.tag_name')
-          echo "Release tag: $release_tag"
-          echo "release_tag=$release_tag" >> $GITHUB_ENV
+          latest_release=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)
+          echo "release_tag=$latest_release" >> $GITHUB_ENV
 
       - name: Append to Latest GitHub Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
### Pull Request Description

This pull request introduces an update to the GitHub Actions workflow, specifically aimed at improving the process of fetching the latest release tag. 

#### Changes Made:
- Refactored the workflow to streamline the command for retrieving the release tag.
- Implemented a direct extraction of the tag name from the API response.
- Updated the environment variable accordingly to reflect the latest tag.

#### Benefits:
These changes enhance the clarity and efficiency of the workflow, making it easier to manage and understand the process of obtaining the latest release tag. This improvement is expected to reduce potential errors and improve the overall performance of the CI/CD pipeline.

Please review the changes and provide any feedback or suggestions. Thank you!