### PR TITLE
🎉 fix: update tag reference in macOS build workflow

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -52,6 +52,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: adbenq_macos_arm.tar.gz
-          tag: ${{ env.release_tag }}
+          tag_name: ${{ env.latest_release }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Change the tag reference in the GitHub Actions workflow for macOS 
builds from `release_tag` to `latest_release` to ensure the correcttag is used for the release process. This improves the accuracy of 
the deployment and aligns with the latest naming conventions.