### PR TITLE
🎉 fix: update tag name for macOS build workflow

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -52,6 +52,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: adbenq_macos_arm.tar.gz
-          tag_name: ${{ env.latest_release }}
+          tag_name: ${{ env.release_tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Change the tag name from `latest_release` to `release_tag` in the 
macOS build workflow. This ensures that the correct release tag is 
used during the GitHub Actions deployment process.