### PR TITLE
✨ chore: remove build verification step and add GH_TOKEN

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -30,13 +30,6 @@ jobs:
           ./build.sh
         shell: bash
 
-      - name: Verify build artifacts
-        run: |
-          if [ ! -f "dist/macos/ADBenQ/ADBenQ" ]; then
-            echo "Build failed: Executable not found!"
-            exit 1
-          fi
-
       - name: Archive the executable
         run: |
           mv dist/macos/ADBenQ/ADBenQ /tmp/ADBenQ
@@ -45,3 +38,5 @@ jobs:
       - name: Add executable to latest release
         run: |
           gh release upload latest adbenq_macos_arm.tar.gz
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Eliminate the build verification step from the macOS workflow to 
streamline the process. Add the GitHub token as an environment 
variable for the release upload step to ensure proper 
authentication during the release process.