### PR TITLE
✨ chore: update release upload method in workflow

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -36,7 +36,7 @@ jobs:
           tar -czf adbenq_macos_arm.tar.gz -C /tmp ADBenQ
 
       - name: Add executable to latest release
-        run: |
-          gh release upload latest adbenq_macos_arm.tar.gz
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: planet-code/upload-to-release-action@1.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          asset-path: adbenq_macos_arm.tar.gz


### PR DESCRIPTION
Replaces the manual upload command with a reusable action for 
uploading the macOS ARM executable to the latest release. This 
improves maintainability and reduces potential errors in the 
workflow.