### PR TITLE
✨ chore: update GitHub Actions to draft releases

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -35,8 +35,13 @@ jobs:
           mv dist/macos/ADBenQ/ADBenQ /tmp/ADBenQ
           tar -czf adbenq_macos_arm.tar.gz -C /tmp ADBenQ
 
-      - name: Add executable to latest release
-        uses: planet-code/upload-to-release-action@1.0.0
+      - name: Draft a release
+        uses: softprops/action-gh-release@v1
         with:
+          files: adbenq_macos_arm.tar.gz
           token: ${{ secrets.GITHUB_TOKEN }}
-          asset-path: adbenq_macos_arm.tar.gz
+          tag_name: ${{ github.sha }}
+          release_name: ${{ github.sha }}
+          body: "macOS executable for commit ${{ github.sha }}"
+          draft: true
+          prerelease: false


### PR DESCRIPTION
Replace the upload-to-release-action with action-gh-release to 
draft releases for macOS executables. This change improves the 
release process by allowing better control over release 
management and ensures that executable is properly taggedwith the commit SHA