### PR TITLE
✨ chore: streamline macOS build workflow for releases

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -35,22 +35,8 @@ jobs:
           mv dist/macos/ADBenQ/ADBenQ /tmp/ADBenQ
           tar -czf adbenq_macos_arm.tar.gz -C /tmp ADBenQ
 
-      - name: Get latest release tag name
-        id: get_latest_release
-        uses: actions/github-script@v6
+      - name: Upload the executable to the latest release
+        uses: softprops/action-gh-release@v1
+        if: ${{startsWith(github.ref, 'refs/tags/') }}
         with:
-          script: |
-            const latestRelease = await github.rest.repos.getLatestRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
-            core.setOutput('tag_name', latestRelease.data.tag_name);
-
-      - name: Upload Release Asset
-        uses: ncipollo/release-action@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          action: uploadAssets
-          artifacts: "adbenq_macos_arm.tar.gz"
-          tag: ${{ steps.get_latest_release.outputs.tag_name }}
-          allowUpdates: true
+          files: adbenq_macos_arm.tar.gz


### PR DESCRIPTION
Refactor the GitHub Actions workflow for macOS builds by 
removing the step to get the latest release tag and 
updating the upload process. This change simplifies the 
release process by directly uploading the executable to 
the latest release using a more efficient action.