### PR TITLE
✨ fix: simplify macOS build archive process

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Archive the executable
         run: |
           mv dist/macos/ADBenQ/ADBenQ /tmp/ADBenQ
-          tar -czf adbenq_macos_arm.tar.gz -C /tmp ADBenQ
+          tar -czf adbenq_macos_arm.tar.gz
 
       - name: Upload the executable to the latest release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Remove unnecessary directory change in the build workflow. This 
streamlines the archiving of the macOS executable, making the 
process more efficient reducing potential errors.