### PR TITLE
✨ chore: update macOS build workflow for artifact upload

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -35,8 +35,8 @@ jobs:
           mv dist/macos/ADBenQ/ADBenQ /tmp/ADBenQ
           tar -czvf ADBenQ-macos.tar.gz -C /tmp ADBenQ
 
-      - name: Upload the executable to the latest release
-        uses: softprops/action-gh-release@v1
-        if: ${{startsWith(github.ref, 'refs/tags/') }}
+      - name: Upload the macOS executable
+        uses: actions/upload-artifact@v4
         with:
-          files: ADBenQ-macos.tar.gz
+          name: ADBenQ-macos
+          path: ADBenQ-macos.tar.gz


### PR DESCRIPTION
Replace the action for uploading the macOS executable to use 
`actions/upload-artifact@v4` instead of `softprops/action-gh-release@v1`. 
This change improves the workflow by that the artifact is 
uploaded correctly and is accessible for later use regardless of 
the tag status.