### PR TITLE
✨ chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
 
@@ -30,7 +30,7 @@ jobs:
           pyinstaller ADBenQ.spec
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ADBenQ
           path: dist/ADBenQ/ADBenQ
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: ADBenQ
           path: ./dist/ADBenQ


### PR DESCRIPTION
Upgrade GitHub Actions in the macOS build workflow to latest 
versions. This includes updating `actions/checkout` to v4, 
`actions/setup-python` to v5, `actions/upload-artifact` to v4, 
and `actions/download-artifact` to v4. These changes enhance 
security, performance, and compatibility with the latest features.