### PR TITLE
✨ chore: Update macOS build workflow for tagging releases

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -1,9 +1,9 @@
-name: Build and Release macOS DMG
+name: Build and Release macOS
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v*"
 
 jobs:
   build:
@@ -29,27 +29,25 @@ jobs:
         run: |
           pyinstaller ADBenQ.spec
 
+      - name: Create tarball
+        run: |
+          tar -czvf ADbenQ_macos.tar.gz dist/ADBenQ
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ADBenQ
-          path: dist/ADBenQ/ADBenQ
+          path: ./ADBenQ_macos.tar.gz
 
   create_release:
     name: Create release
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ADBenQ
-          path: ./dist/ADBenQ
-
       - name: Create draft release
         uses: softprops/action-gh-release@v1
         with:
-          files: ./dist/ADBenQ/ADBenQ
+          files: ./ADBenQ_macos.tar.gz
           tag_name: v${{ github.run_number }}
           name: v${{ github.run_number }}
           draft: true


### PR DESCRIPTION
Change the macOS build workflow to trigger on version tags instead 
of the main branch. Create a tarball of the built application and 
upload it as an artifact. Update the release creation step to use 
the new tarball instead of the previous build output. This improves 
the release process by ensuring that only tagged versions are built 
and released.