### PR TITLE
✨ chore: update macOS build workflow for main branch

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -2,8 +2,8 @@ name: Build and Release macOS
 
 on:
   push:
-    tags:
-      - "v*"
+    branches:
+      - main
 
 jobs:
   build:
@@ -44,6 +44,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ADBenQ
+          path: ./ADBenQ_macos.tar.gz
+
       - name: Create draft release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
Change the trigger for the macOS build workflow from tags to the 
main branch. Add a step to download the artifact before creating 
the draft release. This ensures that the build process runs on 
the latest code and includes the necessary artifacts for the 
release.