### PR TITLE
🎨 fix: update file path for macOS build workflow

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -48,12 +48,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ADBenQ
-          path: ./ADBenQ_macos.tar.gz
 
       - name: Create draft release
         uses: softprops/action-gh-release@v1
         with:
-          files: ./ADBenQ_macos.tar.gz
-          tag_name: v${{ github.run_number }}
-          name: v${{ github.run_number }}
+          files: ADBenQ_macos.tar.gz
           draft: true


### PR DESCRIPTION
Corrects the file path for the macOS build workflow in the GitHub Actions 
configuration. This change ensures that the artifact is referenced 
consistently, improving the reliability of the draft release process.